### PR TITLE
libde265 1.0.15 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,9 +43,11 @@ about:
     multithreading and includes SSE optimizations. The decoder includes all
     features of the Main profile and correctly decodes almost all conformance
     streams.
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  license_file: COPYING
+  license: LGPL-3.0-or-later AND MIT
+  license_family: Other
+  license_file:
+    - COPYING         # LGPL 3.0
+    - dec265/COPYING  # MIT for examples
   doc_url: https://github.com/strukturag/libde265/wiki/Decoder-API-Tutorial
   dev_url: https://github.com/strukturag/libde265
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
     - dec265 -h
 
 about:
-  home: http://www.libde265.org/
+  home: https://www.libde265.org/
   summary: Open h.265 video codec implementation
   description: |
     libde265 is an open source implementation of the h.265 video codec.
@@ -46,6 +46,7 @@ about:
   license: LGPL-3.0-or-later
   license_family: LGPL
   license_file: COPYING
+  doc_url: https://github.com/strukturag/libde265/wiki/Decoder-API-Tutorial
   dev_url: https://github.com/strukturag/libde265
 
 extra:


### PR DESCRIPTION
libde265 1.0.15 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6335]
- dev_url:        https://github.com/strukturag/libde265/tree/v1.0.15
- conda_forge:    https://github.com/conda-forge/libde265-feedstock
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- feedstock added to aggregate
- tweak URLs
- the examples (the `dec265` executable) are under an MIT license
- the `testdata` (with a sample file) is not in the archive tarball so no useful testing


[PKG-6335]: https://anaconda.atlassian.net/browse/PKG-6335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ