### PR TITLE
libde265 1.0.15 rebuild ❄️ 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,14 +23,14 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libde265${SHLIB_EXT}      # [unix]
-    - test -f $PREFIX/include/libde265/de265.h      # [unix]
-    - test -f $PREFIX/lib/pkgconfig/libde265.pc      # [unix]
-    - test -f $PREFIX/lib/cmake/libde265/libde265Config.cmake      # [unix]
-    - if not exist %LIBRARY_LIB%\de265.lib exit 1       # [win]
-    - if not exist %LIBRARY_BIN%\libde265.dll exit 1       # [win]
-    - if not exist %LIBRARY_INC%\libde265\de265.h exit 1       # [win]
-    - if not exist %LIBRARY_LIB%\cmake\libde265\libde265Config.cmake exit 1       # [win]
+    - test -f $PREFIX/lib/libde265${SHLIB_EXT}                              # [unix]
+    - test -f $PREFIX/include/libde265/de265.h                              # [unix]
+    - test -f $PREFIX/lib/pkgconfig/libde265.pc                             # [unix]
+    - test -f $PREFIX/lib/cmake/libde265/libde265Config.cmake               # [unix]
+    - if not exist %LIBRARY_LIB%\de265.lib exit 1                           # [win]
+    - if not exist %LIBRARY_BIN%\libde265.dll exit 1                        # [win]
+    - if not exist %LIBRARY_INC%\libde265\de265.h exit 1                    # [win]
+    - if not exist %LIBRARY_LIB%\cmake\libde265\libde265Config.cmake exit 1 # [win]
     - dec265 -h
 
 about:


### PR DESCRIPTION
libde265 1.0.15 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6335]
- dev_url:        https://github.com/strukturag/libde265/tree/v1.0.15
- conda_forge:    https://github.com/conda-forge/libde265-feedstock
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

The previous PR #1 's merge commit died complaining about a missing `main` ??

- feedstock deleted and re-added to aggregate
- align comments for something to do...

[PKG-6335]: https://anaconda.atlassian.net/browse/PKG-6335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ