### PR TITLE
libde265 1.0.18 

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,6 +12,13 @@ if [[ "${target_platform}" == "osx-arm64" ]]; then
   EXTRA_FLAGS="${EXTRA_FLAGS} -DDISABLE_SSE=ON"
 fi
 
+# $BUILD_PREFIX/bin/../x86_64-conda-linux-gnu/bin/ld: libde265/libde265.so.0.1.11: undefined reference to `pthread_create'
+#$BUILD_PREFIX/bin/../x86_64-conda-linux-gnu/bin/ld: libde265/libde265.so.0.1.11: undefined reference to `pthread_join'
+if [[ "$target_platform" == linux-* ]]
+then
+  export LDFLAGS="${LDFLAGS} -lpthread"
+fi
+
 cmake ${CMAKE_ARGS} -G "Ninja" \
   -DCMAKE_INSTALL_PREFIX="$PREFIX" \
   -DCMAKE_PREFIX_PATH="$PREFIX" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,6 +24,7 @@ cmake ${CMAKE_ARGS} -G "Ninja" \
   -DCMAKE_PREFIX_PATH="$PREFIX" \
   -DCMAKE_SYSTEM_PREFIX_PATH="$PREFIX" \
   -DCMAKE_BUILD_TYPE="Release" \
+  -DCMAKE_SHARED_LINKER_FLAGS="-lpthread" \
   ${EXTRA_FLAGS} \
   ..
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "libde265" %}
-{% set version = "1.0.15" %}
+{% set version = "1.0.18" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/strukturag/libde265/releases/download/v{{ version }}/libde265-{{ version }}.tar.gz
-  sha256: 00251986c29d34d3af7117ed05874950c875dd9292d016be29d3b3762666511d
+  url: https://github.com/strukturag/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 800478f3bf35f0621b14928ceb317579f3e8b23de4bd2aac29b6cb8be962bbd8
 
 build:
   number: 0
@@ -17,9 +17,10 @@ build:
 requirements:
   build:
     - gnuconfig  # [unix]
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - cmake
-    - ninja
+    - ninja-base
 
 test:
   commands:
@@ -34,7 +35,7 @@ test:
     - dec265 -h
 
 about:
-  home: https://www.libde265.org/
+  home: https://www.libde265.org
   summary: Open h.265 video codec implementation
   description: |
     libde265 is an open source implementation of the h.265 video codec.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,14 +24,14 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libde265${SHLIB_EXT}                              # [unix]
-    - test -f $PREFIX/include/libde265/de265.h                              # [unix]
-    - test -f $PREFIX/lib/pkgconfig/libde265.pc                             # [unix]
-    - test -f $PREFIX/lib/cmake/libde265/libde265Config.cmake               # [unix]
-    - if not exist %LIBRARY_LIB%\de265.lib exit 1                           # [win]
-    - if not exist %LIBRARY_BIN%\libde265.dll exit 1                        # [win]
-    - if not exist %LIBRARY_INC%\libde265\de265.h exit 1                    # [win]
-    - if not exist %LIBRARY_LIB%\cmake\libde265\libde265Config.cmake exit 1 # [win]
+    - test -f $PREFIX/lib/libde265${SHLIB_EXT}                               # [unix]
+    - test -f $PREFIX/include/libde265/de265.h                               # [unix]
+    - test -f $PREFIX/lib/pkgconfig/libde265.pc                              # [unix]
+    - test -f $PREFIX/lib/cmake/libde265/libde265-config.cmake               # [unix]
+    - if not exist %LIBRARY_LIB%\de265.lib exit 1                            # [win]
+    - if not exist %LIBRARY_BIN%\libde265.dll exit 1                         # [win]
+    - if not exist %LIBRARY_INC%\libde265\de265.h exit 1                     # [win]
+    - if not exist %LIBRARY_LIB%\cmake\libde265\libde265-config.cmake exit 1 # [win]
     - dec265 -h
 
 about:


### PR DESCRIPTION
libde265 1.0.18 

**Destination channel:** Defaults

### Links

- [PKG-14327]
- dev_url:        https://github.com/strukturag/libde265/tree/v1.0.18
- conda_forge:    https://github.com/conda-forge/libde265-feedstock
- pypi:           https://google.com
- pypi inspector: https://google.com

### Explanation of changes:

- new version number


[PKG-14327]: https://anaconda.atlassian.net/browse/PKG-14327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ